### PR TITLE
Support Databox API version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+Following guidelines of http://keepachangelog.com/
+
+## [Unreleased]
+- update to support Databox API version 3
+
+## [0.2.2] - Jan 24, 2016
+Databox API has changed a bit in part dedicated for retrieving last pushes. This SDK was updated accordingly.
+
+## [0.2.1] - Jul 22, 2015
+Support for additional attributes
+Test for additional attributes support
+Updated README.md example
+
+[Unreleased]: https://github.com/databox/databox-ruby/compare/0.2.2...master
+[0.2.2]: https://github.com/databox/databox-ruby/compare/0.2.1...0.2.2
+[0.2.1]: https://github.com/databox/databox-ruby/tree/0.2.1

--- a/example.rb
+++ b/example.rb
@@ -13,5 +13,6 @@ client = Databox::Client.new()
 	client.push(key: "example.ruby", value: t*100, date:(DateTime.now - t).strftime('%Y-%m-%d'))
 end
 
-pp client.last_push(3)
+client.push(key: "example.ruby.unit", value: 100, unit: "USD")
 
+pp client.last_push(3)

--- a/lib/databox/client.rb
+++ b/lib/databox/client.rb
@@ -4,7 +4,8 @@ require 'json'
 class Databox::Client
   include HTTParty
   format :json
-  headers 'User-Agent' => "Databox/#{Databox::VERSION} (Ruby)"
+  headers 'User-Agent' => "databox-ruby/#{Databox::VERSION}"
+  headers 'Accept' => "application/vnd.databox.v#{Databox::VERSION.split('.')[0]}+json"
   debug_output if [1, "1"].include?(ENV["HTTPARTY_DEBUG"])
   default_timeout 1 if ENV["DATABOX_MODE"] == "test"
 
@@ -57,15 +58,15 @@ class Databox::Client
 
   def push(kpi={})
     self.last_push_content = raw_push('/', [process_kpi(kpi)])
-    self.last_push_content['status'] == 'ok'
+    self.last_push_content.key?('id')
   end
 
   def insert_all(rows=[])
     self.last_push_content = raw_push('/', rows.map {|r| process_kpi(r) })
-    self.last_push_content['status'] == 'ok'
+    self.last_push_content.key?('id')
   end
 
   def last_push(n=1)
-    handle self.class.get("/lastpushes/#{n}")
+    handle self.class.get("/lastpushes?limit=#{n}")
   end
 end

--- a/lib/databox/configuration.rb
+++ b/lib/databox/configuration.rb
@@ -2,7 +2,7 @@ class Databox::Configuration
   attr_accessor :push_token, :push_host
 
   def initialize
-    @push_host ||= 'https://push2new.databox.com'
+    @push_host ||= 'https://push.databox.com'
     @push_token ||= ENV['DATABOX_PUSH_TOKEN']
   end
 end

--- a/lib/databox/version.rb
+++ b/lib/databox/version.rb
@@ -1,3 +1,3 @@
 module Databox
-  VERSION = '0.2.2'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
Update SDK to support Databox API version 3

changes:
- [x] update request headers
- [x] update `GET /lastpushes`
- [x] handle new response
